### PR TITLE
Fix #19: Active state on nav links when using baseurl

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -12,7 +12,7 @@
         {% else %}
           {% assign url = link.url | relative_url %}
         {% endif %}
-        <li class="{% if page.url contains {{url}} %}uk-active{% endif %}"><a href="{{ url }}">{{ link.title }}</a></li>
+        <li class="{% if page.url contains link.url %}uk-active{% endif %}"><a href="{{ url }}">{{ link.title }}</a></li>
         {% endfor %}
         {% for link in site.data.navigation.toggle %}
         {% if link.url contains "https" %}
@@ -20,7 +20,7 @@
         {% else %}
           {% assign url = link.url | relative_url %}
         {% endif %}
-        <li class="{% if page.url contains {{url}} %}uk-active{% endif %}">
+        <li class="{% if page.url contains link.url %}uk-active{% endif %}">
           <a href="{{ url }}">{{ link.title }}</a>
           <div class="uk-navbar-dropdown uk-border-rounded uk-background-muted">
             <ul class="uk-nav uk-navbar-dropdown-nav">
@@ -30,7 +30,7 @@
                   {% else %}
                   {% assign url = link.url | relative_url %}
                   {% endif %}
-                  <li class="{% if page.url contains {{url}} %}uk-active{% endif %} uk-nav-header"><a href="{{ url }}">{{ link.title }}</a></li>
+                  <li class="{% if page.url contains link.url %}uk-active{% endif %} uk-nav-header"><a href="{{ url }}">{{ link.title }}</a></li>
               {% endfor %}
             </ul>
           </div>
@@ -51,7 +51,7 @@
                   {% else %}
                   {% assign url = link.url | relative_url %}
                 {% endif %}
-                  <li class="{% if page.url contains {{url}} %}uk-active{% endif %} uk-nav-header"><a href="{{ url }}">{{ link.title }}</a></li>{% unless forloop.last %} <hr> {% endunless %}
+                  <li class="{% if page.url contains link.url %}uk-active{% endif %} uk-nav-header"><a href="{{ url }}">{{ link.title }}</a></li>{% unless forloop.last %} <hr> {% endunless %}
               {% endfor %}
             </ul>
           </div>


### PR DESCRIPTION
## Summary
I've done a couple of things in this PR:
- Remove the liquid brackets on the `url` key inside the `if` statement, they aren't needed
- Checked the original `link.url` against the current page url, so the current class will be added even if the site has been configured with a `baseurl`

fixes #19 