### PR TITLE
Feature #7: Add Formspree / Netlify form include

### DIFF
--- a/_includes/contact-form.html
+++ b/_includes/contact-form.html
@@ -1,0 +1,56 @@
+{% if include.name %}
+  {% assign name = include.name %}
+{% else %}
+  {% assign name = "Contact" %}
+{% endif %}
+
+{% assign name_id = name | downcase | replace: " ", "-" %}
+
+{% if include.thanks_url %}
+  {% assign thanks_url = include.thanks_url %}
+{% else %}
+  {% assign thanks_url = "/thanks/" %}
+{% endif %}
+
+<form class="form  form--{{ name_id }}" method="post" name="{{ name }}" action="{{ thanks_url }}"
+  {% if include.netlify_form %}
+    netlify-honeypot="bot-field"
+    netlify
+  {% endif %}
+>
+  <fieldset class="uk-fieldset">
+
+    <legend class="uk-legend">{{ name }}</legend>
+
+    <div class="uk-margin">
+      <label>Name:<input class="uk-input" id="name--{{ name_id }}" type="text" name="name" value="" placeholder="Your Name" required="required" /></label>
+    </div>
+
+    <div class="uk-margin">
+      <label>Email Address:<input class="uk-input" id="email--{{ name_id }}" type="email" name="email" value="" placeholder="email@website.com" required="required" /></label>
+    </div>
+
+    <div class="uk-margin">
+      <label class="label" for="message--{{ name_id }}">Message:<textarea class="uk-textarea" id="message--{{ name_id }}" name="message" placeholder="Your message..." required="required"></textarea></label>
+    </div>
+
+    <input class="uk-button uk-button-primary" type="submit" value="Send message" />
+
+    {% if include.netlify_form %}
+      <label  style="display:none">Don’t fill this out if you’re human: <input name="bot-field" /></label>
+    {% else %}
+      <input type="text" name="_gotcha" style="display:none">
+      <input type="hidden" name="_subject" value="{{ site.title }} submission from {{ name }}">
+      <input type="hidden" name="_next" value="{{ thanks_url }}" />
+    {% endif %}
+  </fieldset>
+</form>
+{% unless include.netlify_form %}
+  <script>
+    var email = "{{ site.email | split: "" | reverse | join: "" }}";
+    var unraveledEmail = email.split("").reverse().join("");
+    var form = document.querySelector(".form--{{ name_id }}");
+      form.setAttribute("action", "https://formspree.io/" + unraveledEmail);
+  </script>
+  <noscript>Please enable JavaScript to use the form.</noscript>
+{% endunless %}

--- a/_posts/2018-10-13-contact-form-example.markdown
+++ b/_posts/2018-10-13-contact-form-example.markdown
@@ -1,0 +1,14 @@
+---
+layout: post
+title: Contact Form Example
+date: "2018-10-13 13:55:00 -0700"
+tags: [test, forms, docs]
+---
+
+The contact form include can be linked with Formspree or Netlify forms, depending on your hosting choice and desired setup.
+
+Set `netlify_form=true` when using the include to use Netlify Forms, otherwise the form will default to Formspree. An optional `name` value can also be set if you're using multiple forms and need a unique identifier.
+
+Use the `email` option in the `/_config.yml` to change to the desired email.
+
+{% include contact-form.html %}


### PR DESCRIPTION
## Summary
This addition adds a contact form include with the option to use Formspree or Netlify Forms. Also comes with a `name` option to label form in multiple instances. Closes #7 
![screen shot 2018-10-14 at 14 02 47](https://user-images.githubusercontent.com/1177460/46917012-29fb4580-cfba-11e8-9213-92f823610c3f.png)

I haven't been able to test this fully yet but I'm optimistic that it should work just fine